### PR TITLE
Web search for persons and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vidrovr/core/response.py
 # ignore some directories
 dist/
 docs/build/
+images/
 vidrovr/__pycache__/
 vidrovr/core/__pycache__/
 vidrovr/resources/__pycache__/

--- a/docs/source/custom_persons.rst
+++ b/docs/source/custom_persons.rst
@@ -30,3 +30,5 @@ along with the PersonExampleModel object:
 .. autofunction:: vidrovr.resources.custom_persons.PersonExample.read
 
 .. autofunction:: vidrovr.resources.custom_persons.PersonExample.update
+
+.. autofunction:: vidrovr.resources.custom_persons.PersonExample.search

--- a/docs/source/custom_tags.rst
+++ b/docs/source/custom_tags.rst
@@ -28,3 +28,5 @@ along with the CustomTagExampleModel data object:
 .. autofunction:: vidrovr.resources.custom_tags.CustomTagExample.read
 
 .. autofunction:: vidrovr.resources.custom_tags.CustomTagExample.update
+
+.. autofunction:: vidrovr.resources.custom_tags.CustomTagExample.search

--- a/vidrovr/resources/custom_persons/person.py
+++ b/vidrovr/resources/custom_persons/person.py
@@ -92,8 +92,8 @@ class Person:
         :type project_id: str
         :param name: Name of the person to be created
         :type name: str
-        :return: JSON string of the HTTP response containing the ID of the new person
-        :rtype: str
+        :return: Data object of a person
+        :rtype: PersonModel
         """
         url     = 'customdata/persons/'
         payload = {
@@ -104,4 +104,12 @@ class Person:
         }
         response = Client.post(url, payload)
 
-        return response
+        if response is not None:
+            person = PersonModel(
+                id=response['id'],
+                name=response['name']
+            )
+
+            return person
+        else:
+            return response

--- a/vidrovr/resources/custom_persons/person_examples.py
+++ b/vidrovr/resources/custom_persons/person_examples.py
@@ -88,5 +88,50 @@ class PersonExample:
         return response
     
     @classmethod
-    def create(cls):
-        return NotImplementedError
+    def create(cls, person_id: str, file_path: str):
+        """
+        Create an example with an image for a specific person ID
+
+        :param person_id: ID of the person
+        :type person_id: str
+        :param file_path: Path to the file to upload
+        :type file_path: str
+        """
+        url = f'customdata/persons/{person_id}/examples'
+        payload = {}
+        files = [
+            ('file_data',('file',open(file_path,'rb'),'application/octet-stream'))
+        ]
+        response = Client.post(url, payload, files)
+
+        if response is not None:
+            example = PersonExampleModel(
+                id=response['id'],
+                name=response['name']
+            )
+
+            return example
+        else:
+            return response
+    
+    @classmethod 
+    def search(cls, person_id: str, project_id: str, query: str):
+        """
+        Triggers a web search for images based on the query
+
+        :param person_id: ID of the person
+        :type person_id: str
+        :param project_id: ID of the project
+        :type project_id: str
+        :param query: Name of the person to use in the search
+        :type query: str
+        """
+        url = f'customdata/persons/{person_id}/examples?project_uid={project_id}'
+        payload = {
+            'data': {
+                'search_query': query
+            }
+        }
+        response = Client.post(url, payload)
+
+        return response

--- a/vidrovr/resources/custom_tags/tag_examples.py
+++ b/vidrovr/resources/custom_tags/tag_examples.py
@@ -96,3 +96,25 @@ class CustomTagExample:
             return tag
         else:
             return response
+        
+    @classmethod
+    def search(cls, tag_id: str, project_id: str, query: str):
+        """
+        Triggers a web search for images based on the query
+
+        :param tag_id: ID of the tag
+        :type tag_id: str
+        :param project_id: ID of the project
+        :type project_id: str
+        :param query: Name of the tag to use in the search
+        :type query: str
+        """
+        url = f'customdata/tags/{tag_id}/examples?project_uid={project_id}'
+        payload = {
+            'data': {
+                'search_query': query
+            }
+        }
+        response = Client.post(url, payload)
+
+        return response


### PR DESCRIPTION
1. Added search methods to the PersonExample and TagExample objects.
2. Added create method for PersonExample.
3. Updated documentation to include new search methods.
4. Updated gitignore to ignore an image folder with test images.

Nothing is returned when executing the search unless it fails. Would be nice if the API sent something back to indicate successful start of the search.